### PR TITLE
webpack popper plugin add

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 module.exports = {
   entry: './browser/index.js',
   output: {
@@ -15,6 +16,14 @@ module.exports = {
           presets: [ 'es2015', 'react']
         }
       }
-    ]
+    ],
+      plugins: [
+      new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+        'window.jQuery': 'jquery',
+        Popper: ['popper.js', 'default']
+      })
+  ]
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,14 +16,14 @@ module.exports = {
           presets: [ 'es2015', 'react']
         }
       }
-    ],
-      plugins: [
+    ]
+  },
+  plugins: [
       new webpack.ProvidePlugin({
         $: 'jquery',
         jQuery: 'jquery',
         'window.jQuery': 'jquery',
         Popper: ['popper.js', 'default']
       })
-  ]
-  }
+    ]
 };


### PR DESCRIPTION
Made an update to the Webpack config to incorporate popper (used in mobile nav) correctly. For more info: https://getbootstrap.com/docs/4.0/getting-started/webpack/

Only this file is committed in this branch